### PR TITLE
Dead blog post #125

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -8,7 +8,7 @@ import { colors, responsive, transitions } from '../styles';
 
 const SFooterWrapper = styled.div`
   width: 100%;
-  position: absolute;
+  position: relative;
   bottom: 0;
 `;
 

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -226,7 +226,7 @@ const Blog = ({ data, errors }) => {
             );
           } else {
             return (
-              <Link key={post.id} to={`blog/${post.slug}`}>
+              <Link key={post.id} to={`${post.slug}`}>
                 <SPostCards medium={post.medium} idx={idx}>
                   <SDivider idx={idx}>
                     <div />


### PR DESCRIPTION
There where two ways of building the link posts: one for Contentful and one for the Medium posts. Due to the fact that the broken link was the only one that used Contentful the problem didn't spread in the blog section. The 'blog' target appeared twice (composed from 'blog/ + post.slug) making the link broken. 
Another problem that I've observed during the investigation was the fact that the 'Page not found' has two problems: is not redirecting every time broken links and the header is overlaying the menu bar.